### PR TITLE
fix: zero-docs magellan links generation

### DIFF
--- a/packages/zero-docs/pages/[...slug].vue
+++ b/packages/zero-docs/pages/[...slug].vue
@@ -32,7 +32,8 @@
               id="markdown"
               :markdown="section.raw"
               :section="content.length > 1 ? section._path.split('/').pop() : ''"
-              class="markdown" />
+              class="markdown"
+              @found-heading-nodes="docsStore.compileMagellanLinks" />
             <ZeroApiOverview
               v-if="section.apiOverview"
               :headers="section.apiOverview.headers"
@@ -257,14 +258,6 @@ watch(route, async route => {
   }, 100)
   navigatedByRoute.value = true
   docsStore.setActiveSection({ id: route.hash.slice(1) })
-  if (process.client) {
-    await nextTick(() => {
-      const linksExist = docsStore.compileMagellanLinks()
-      if (linksExist) {
-        docsStore.setActiveLinkMarkerHeight()
-      }
-    })
-  }
 }, { immediate: true })
 
 // ======================================================================= Hooks

--- a/packages/zero-docs/stores/docs.js
+++ b/packages/zero-docs/stores/docs.js
@@ -62,8 +62,11 @@ export const useZeroDocsStore = defineStore('docs', () => {
    * @method compileMagellanLinks
    */
 
-  const compileMagellanLinks = () => {
-    const headings = Array.from(document.querySelectorAll('#markdown *[id]'))
+  const compileMagellanLinks = headings => {
+    if (headings.length === 0) {
+      magellanLinks.value = []
+      return
+    }
     magellanLinks.value = headings.reduce((acc, item) => {
       acc.push({
         level: `level-${item.localName}`,
@@ -74,7 +77,7 @@ export const useZeroDocsStore = defineStore('docs', () => {
       })
       return acc
     }, [])
-    return magellanLinks.value.length > 0
+    setActiveLinkMarkerHeight()
   }
 
   /**


### PR DESCRIPTION
`ZeroMarkdownParser` now emits collection of heading nodes `onMounted` and `zero-docs` uses them to compile magellan links, instead of trying to `await nextTick()` outside of the markdown parser